### PR TITLE
엔티티들의 메타데이터 equals, hashcode 중복 제거

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -57,20 +57,19 @@ public class Article extends AuditingFields {
         if(this.getId() != null) { // id가 영속화가 된 경우
             return Objects.equals(this.getId(),that.getId());
         } else { // 영속화하지 않은 데이터도 처리 하기위해서 분기 처리
-            AuditingFields thisAuditingField = this;
             return Objects.equals(this.getTitle(), that.getTitle()) &&
                     Objects.equals(this.getContent(), that.getContent()) &&
                     Objects.equals(this.getHashtag(), that.getHashtag()) &&
-                    thisAuditingField.equals(that);
+                    super.equals(that);
         }
     }
 
     @Override
     public int hashCode() {
-        if(this.getId() != null) {
+        if (this.getId() != null) {
             return Objects.hash(getId());
-        }else {
-            return Objects.hash(getTitle(), getContent(), getHashtag(), super.hashCode());
+        } else {
+            return Objects.hash(getTitle(), getContent(), getHashtag()) + super.hashCode();
         }
     }
 }

--- a/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -35,19 +35,29 @@ public class ArticleComment extends AuditingFields{
     }
 
     public static ArticleComment of(Article article, String content) {
-        return new ArticleComment(article,content);
+        return new ArticleComment(article, content);
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ArticleComment articleComment = (ArticleComment) o;
-        return Objects.equals(getId(), articleComment.getId());
+        if (!(o instanceof ArticleComment that)) return false;
+
+        if (this.getId() != null) { // id가 영속화가 된 경우
+            return Objects.equals(this.getId(), that.getId());
+        } else { // 영속화하지 않은 데이터도 처리 하기위해서 분기 처리
+            return Objects.equals(this.getArticle(), that.getArticle()) &&
+                    Objects.equals(this.getContent(), that.getContent()) &&
+                    super.equals(that);
+        }
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId());
+        if (this.getId() != null) {
+            return Objects.hash(getId());
+        } else {
+            return Objects.hash(getArticle(), getContent()) + super.hashCode();
+        }
     }
 }

--- a/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
@@ -61,10 +61,7 @@ public class UserAccount extends AuditingFields {
                     Objects.equals(this.getEmail(), that.getEmail()) &&
                     Objects.equals(this.getNickname(), that.getNickname()) &&
                     Objects.equals(this.getMemo(), that.getMemo()) &&
-                    Objects.equals(this.getCreatedAt(), that.getCreatedAt()) &&
-                    Objects.equals(this.getCreatedBy(), that.getCreatedBy()) &&
-                    Objects.equals(this.getModifiedAt(), that.getModifiedAt()) &&
-                    Objects.equals(this.getModifiedBy(), that.getModifiedBy());
+                    super.equals(that);
         }
 
         return Objects.equals(this.getId(), that.getId());
@@ -73,7 +70,7 @@ public class UserAccount extends AuditingFields {
     @Override
     public int hashCode() {
         if (this.getId() == null) {
-            return Objects.hash(getUserLogin(), getUserPassword(), getEmail(), getNickname(), getMemo(), getCreatedAt(), getCreatedBy(), getModifiedAt(), getModifiedBy());
+            return Objects.hash(getUserLogin(), getUserPassword(), getEmail(), getNickname(), getMemo()) + super.hashCode();
         }
 
         return Objects.hash(getId());

--- a/src/test/java/com/fastcampus/projectboard/domain/TestArticle.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/TestArticle.java
@@ -42,7 +42,11 @@ public class TestArticle extends AuditingFields {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getTitle(), getContent(), getHashtag(), getCreatedAt(), getCreatedBy(), getModifiedAt(), getModifiedBy());
+        return Objects.hash(getTitle(), getContent(), getHashtag()) + super.hashCode();
+    }
+
+    public int nestedHashcode() {
+        return Objects.hash(getTitle(),getContent(),getHashtag(),super.hashCode());
     }
 
     @Override

--- a/src/test/java/com/fastcampus/projectboard/domain/TestArticle.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/TestArticle.java
@@ -1,0 +1,74 @@
+package com.fastcampus.projectboard.domain;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class TestArticle extends AuditingFields {
+
+    private final String title;
+    private final String content;
+    private final String hashtag;
+
+
+    private TestArticle(LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, String title, String content, String hashtag) {
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
+        this.modifiedAt = modifiedAt;
+        this.modifiedBy = modifiedBy;
+
+        this.title = title;
+        this.content = content;
+        this.hashtag = hashtag;
+    }
+
+    public static TestArticle of(LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, String title, String content, String hashtag) {
+        return new TestArticle(createdAt, createdBy, modifiedAt, modifiedBy, title, content, hashtag);
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TestArticle that)) return false;
+
+        return Objects.equals(this.getTitle(), that.getTitle()) &&
+                Objects.equals(this.getContent(), that.getContent()) &&
+                Objects.equals(this.getHashtag(), that.getHashtag()) &&
+                Objects.equals(this.getCreatedAt(), that.getCreatedAt()) &&
+                Objects.equals(this.getCreatedBy(), that.getCreatedBy()) &&
+                Objects.equals(this.getModifiedAt(), that.getModifiedAt()) &&
+                Objects.equals(this.getModifiedBy(), that.getModifiedBy());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getTitle(), getContent(), getHashtag(), getCreatedAt(), getCreatedBy(), getModifiedAt(), getModifiedBy());
+    }
+
+    @Override
+    public String toString() {
+        return "TestArticle{" +
+                "auditingField{" +
+                "createdAt=" + createdAt +
+                ", createdBy='" + createdBy + '\'' +
+                ", modifiedAt=" + modifiedAt +
+                ", modifiedBy='" + modifiedBy + '\'' +
+                "}" +
+                ", title='" + title + '\'' +
+                ", content='" + content + '\'' +
+                ", hashcode='" + hashtag + '\'' +
+                '}';
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getHashtag() {
+        return hashtag;
+    }
+}

--- a/src/test/java/com/fastcampus/projectboard/domain/TestArticle.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/TestArticle.java
@@ -34,10 +34,7 @@ public class TestArticle extends AuditingFields {
         return Objects.equals(this.getTitle(), that.getTitle()) &&
                 Objects.equals(this.getContent(), that.getContent()) &&
                 Objects.equals(this.getHashtag(), that.getHashtag()) &&
-                Objects.equals(this.getCreatedAt(), that.getCreatedAt()) &&
-                Objects.equals(this.getCreatedBy(), that.getCreatedBy()) &&
-                Objects.equals(this.getModifiedAt(), that.getModifiedAt()) &&
-                Objects.equals(this.getModifiedBy(), that.getModifiedBy());
+                super.equals(that);
     }
 
     @Override
@@ -46,7 +43,7 @@ public class TestArticle extends AuditingFields {
     }
 
     public int nestedHashcode() {
-        return Objects.hash(getTitle(),getContent(),getHashtag(),super.hashCode());
+        return Objects.hash(getTitle(), getContent(), getHashtag(), super.hashCode());
     }
 
     @Override

--- a/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
@@ -41,9 +41,7 @@ public class ArticleAuditingFieldsTest {
         TestArticle testArticle1 = getTestArticleDiff(1);
         TestArticle testArticle2 = getTestArticleDiff(1);
 
-        // when
-
-        // then
+        // when & then
         assertThat(testArticle1).isEqualTo(testArticle2);
         assertThat(testArticle1.hashCode()).isEqualTo(testArticle2.hashCode());
     }

--- a/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
@@ -1,6 +1,7 @@
 package com.fastcampus.projectboard.domain.test;
 
 import com.fastcampus.projectboard.domain.TestArticle;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +16,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("[AuditingField] AuditingFields equals hashcode 메서드 테스트")
 public class ArticleAuditingFieldsTest {
 
-    private final LocalDateTime now = LocalDateTime.now();
+    private LocalDateTime now;
+
+    @BeforeEach
+    void timeInit() {
+        now = LocalDateTime.now();
+    }
 
     @DisplayName("서로다른 5개의 객체 중복 비교")
     @Test

--- a/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
@@ -1,0 +1,81 @@
+package com.fastcampus.projectboard.domain.test;
+
+import com.fastcampus.projectboard.domain.TestArticle;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("[AuditingField] AuditingFields equals hashcode 메서드 테스트")
+public class ArticleAuditingFieldsTest {
+
+    private LocalDateTime now;
+
+    @BeforeEach
+    void timeInit() {
+        now = LocalDateTime.now();
+    }
+
+    @DisplayName("서로다른 5개의 객체 중복 비교")
+    @Test
+    void givenTestArticles_whenDistinct_thenNotDuplication() {
+        // given
+        List<TestArticle> testArticles = getDiffFiveArticles();
+
+        // when
+        List<TestArticle> removeDuplicateData = testArticles.stream().distinct().toList();
+
+        // then
+        assertThat(removeDuplicateData.size()).isEqualTo(testArticles.size());
+    }
+
+    @DisplayName("모든 필드값이 같은 2개의 객체 중복 비교")
+    @Test
+    void givenTwoSameTestArticle_when_thenSameTestArticle() {
+        // given
+        TestArticle testArticle1 = getTestArticleDiff(1);
+        TestArticle testArticle2 = getTestArticleDiff(1);
+        // when
+
+        // then
+        assertThat(testArticle1).isEqualTo(testArticle2);
+        assertThat(testArticle1.hashCode()).isEqualTo(testArticle2.hashCode());
+    }
+
+    @DisplayName("AuditingField만 다른 2개의 객체 중복 비교")
+    @Test
+    void givenTwoSameAuditingFieldTestArticle_when_thenDiffTestArticle() {
+        // given
+        TestArticle testArticle1 = getTestArticleAuditingFieldDiff(1);
+        TestArticle testArticle2 = getTestArticleAuditingFieldDiff(2);
+        // when
+
+        // then
+        assertThat(testArticle1).isNotEqualTo(testArticle2);
+        assertThat(testArticle1.hashCode()).isNotEqualTo(testArticle2.hashCode());
+    }
+
+    private List<TestArticle> getDiffFiveArticles() {
+        List<TestArticle> result = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            TestArticle testArticle = getTestArticleDiff(i);
+            result.add(testArticle);
+        }
+        return result;
+    }
+
+    private TestArticle getTestArticleDiff(int number) {
+        return TestArticle.of(now.plusMinutes(number), "createdName" + number, now.plusMinutes(modifiedTime + number), "modifiedName" + number, "title" + number, "content" + number, "hashtag" + number);
+    }
+
+    private TestArticle getTestArticleAuditingFieldDiff(int number) {
+        return TestArticle.of(now.plusMinutes(number), "createdName" + number, now.plusMinutes(modifiedTime + number), "modifiedName" + number, "title", "content", "hashtag");
+    }
+
+    private final int modifiedTime = 3;
+}

--- a/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
@@ -1,7 +1,6 @@
 package com.fastcampus.projectboard.domain.test;
 
 import com.fastcampus.projectboard.domain.TestArticle;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -16,12 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("[AuditingField] AuditingFields equals hashcode 메서드 테스트")
 public class ArticleAuditingFieldsTest {
 
-    private LocalDateTime now;
-
-    @BeforeEach
-    void timeInit() {
-        now = LocalDateTime.now();
-    }
+    private final LocalDateTime now = LocalDateTime.now();
 
     @DisplayName("서로다른 5개의 객체 중복 비교")
     @Test

--- a/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
@@ -40,6 +40,7 @@ public class ArticleAuditingFieldsTest {
         // given
         TestArticle testArticle1 = getTestArticleDiff(1);
         TestArticle testArticle2 = getTestArticleDiff(1);
+
         // when
 
         // then
@@ -58,6 +59,22 @@ public class ArticleAuditingFieldsTest {
         // then
         assertThat(testArticle1).isNotEqualTo(testArticle2);
         assertThat(testArticle1.hashCode()).isNotEqualTo(testArticle2.hashCode());
+    }
+
+    @DisplayName("내부적으로 hashcode를 두번 호출하는 메서드 테스트")
+    @Test
+    void givenTestArticle_whenCalculateHashcode_thenDiffHashcode() {
+        // given
+        TestArticle testArticle1 = getTestArticleDiff(1);
+
+        // when
+        int hashcode = testArticle1.hashCode();
+        int nestedHashcode = testArticle1.nestedHashcode();
+
+        // then
+        System.out.println("hashcode = " + hashcode);
+        System.out.println("nestedHashcode = " + nestedHashcode);
+        assertThat(hashcode).isNotEqualTo(nestedHashcode);
     }
 
     private List<TestArticle> getDiffFiveArticles() {

--- a/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,14 +26,12 @@ public class ArticleAuditingFieldsTest {
     @DisplayName("서로다른 5개의 객체 중복 비교")
     @Test
     void givenTestArticles_whenDistinct_thenNotDuplication() {
-        // given
-        List<TestArticle> testArticles = getDiffFiveArticles();
-
-        // when
-        List<TestArticle> removeDuplicateData = testArticles.stream().distinct().toList();
+        // given & when
+        int fiveArticlesSize = getDiffFiveArticles().size();
+        Set<TestArticle> testArticles = new HashSet<>(getDiffFiveArticles());
 
         // then
-        assertThat(removeDuplicateData.size()).isEqualTo(testArticles.size());
+        assertThat(fiveArticlesSize).isEqualTo(testArticles.size());
     }
 
     @DisplayName("모든 필드값이 같은 2개의 객체 중복 비교")


### PR DESCRIPTION
엔티티들의 비영속 equals 비교의 경우
AuditingFields를 상속하고 있더라도
AuditingFields의 필드를 가져와서 사용합니다.

그러므로 AuditingFields의 equals를 재정의한다면
AuditingFields 메타데이터를 보유하고있는 엔티티의 equals 중복값이 삭제되기때문에 더 편리하다고 생각했습니다.

이 pr의 경우 히스토리가 존재합니다.
#9 에서 작업했으나 #9에서 작업하기 적절하지 않아서 따로 브랜치를 분리해서 작업했습니다.

This closes #19 