### PR TITLE
[리팩토링] TestArticle equals, hashcode 관련 테스트코드 리팩토링

### DIFF
--- a/.github/workflows/CI-java-gradle.yml
+++ b/.github/workflows/CI-java-gradle.yml
@@ -33,8 +33,18 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
+    - name: Mysql 설치
+      uses: samin/mysql-action@v1
+      with:
+        host port: 3306
+        container port: 3306
+        mysql database: 'board'
+        mysql user: ${{ secrets.DATABASE_USERNAME }}
+        mysql password: ${{ secrets.DATABASE_PASSWORD }}
+
     - name: Build with Gradle Wrapper
       run: ./gradlew build
+
 
     # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
     # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.

--- a/src/test/java/com/fastcampus/projectboard/domain/TestArticle.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/TestArticle.java
@@ -42,10 +42,6 @@ public class TestArticle extends AuditingFields {
         return Objects.hash(getTitle(), getContent(), getHashtag()) + super.hashCode();
     }
 
-    public int nestedHashcode() {
-        return Objects.hash(getTitle(), getContent(), getHashtag(), super.hashCode());
-    }
-
     @Override
     public String toString() {
         return "TestArticle{" +

--- a/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
@@ -27,8 +27,9 @@ public class ArticleAuditingFieldsTest {
     @Test
     void givenTestArticles_whenDistinct_thenNotDuplication() {
         // given & when
-        int fiveArticlesSize = getDiffFiveArticles().size();
-        Set<TestArticle> testArticles = new HashSet<>(getDiffFiveArticles());
+        List<TestArticle> articles = getDiffFiveArticles();
+        int fiveArticlesSize = articles.size();
+        Set<TestArticle> testArticles = new HashSet<>(articles);
 
         // then
         assertThat(fiveArticlesSize).isEqualTo(testArticles.size());

--- a/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
@@ -60,22 +60,6 @@ public class ArticleAuditingFieldsTest {
         assertThat(testArticle1.hashCode()).isNotEqualTo(testArticle2.hashCode());
     }
 
-    @DisplayName("내부적으로 hashcode를 두번 호출하는 메서드 테스트")
-    @Test
-    void givenTestArticle_whenCalculateHashcode_thenDiffHashcode() {
-        // given
-        TestArticle testArticle1 = createTestArticleWithOffset(1);
-
-        // when
-        int hashcode = testArticle1.hashCode();
-        int nestedHashcode = testArticle1.nestedHashcode();
-
-        // then
-        System.out.println("hashcode = " + hashcode);
-        System.out.println("nestedHashcode = " + nestedHashcode);
-        assertThat(hashcode).isNotEqualTo(nestedHashcode);
-    }
-
     private List<TestArticle> createDiffFiveArticles() {
         List<TestArticle> result = new ArrayList<>();
         for (int i = 1; i <= 5; i++) {

--- a/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/test/ArticleAuditingFieldsTest.java
@@ -27,7 +27,7 @@ public class ArticleAuditingFieldsTest {
     @Test
     void givenTestArticles_whenDistinct_thenNotDuplication() {
         // given & when
-        List<TestArticle> articles = getDiffFiveArticles();
+        List<TestArticle> articles = createDiffFiveArticles();
         int fiveArticlesSize = articles.size();
         Set<TestArticle> testArticles = new HashSet<>(articles);
 
@@ -39,8 +39,8 @@ public class ArticleAuditingFieldsTest {
     @Test
     void givenTwoSameTestArticle_when_thenSameTestArticle() {
         // given
-        TestArticle testArticle1 = getTestArticleDiff(1);
-        TestArticle testArticle2 = getTestArticleDiff(1);
+        TestArticle testArticle1 = createTestArticleWithOffset(1);
+        TestArticle testArticle2 = createTestArticleWithOffset(1);
 
         // when & then
         assertThat(testArticle1).isEqualTo(testArticle2);
@@ -51,8 +51,8 @@ public class ArticleAuditingFieldsTest {
     @Test
     void givenTwoSameAuditingFieldTestArticle_when_thenDiffTestArticle() {
         // given
-        TestArticle testArticle1 = getTestArticleAuditingFieldDiff(1);
-        TestArticle testArticle2 = getTestArticleAuditingFieldDiff(2);
+        TestArticle testArticle1 = createTestArticleWithOffsetAuditingFields(1);
+        TestArticle testArticle2 = createTestArticleWithOffsetAuditingFields(2);
         // when
 
         // then
@@ -64,7 +64,7 @@ public class ArticleAuditingFieldsTest {
     @Test
     void givenTestArticle_whenCalculateHashcode_thenDiffHashcode() {
         // given
-        TestArticle testArticle1 = getTestArticleDiff(1);
+        TestArticle testArticle1 = createTestArticleWithOffset(1);
 
         // when
         int hashcode = testArticle1.hashCode();
@@ -76,20 +76,20 @@ public class ArticleAuditingFieldsTest {
         assertThat(hashcode).isNotEqualTo(nestedHashcode);
     }
 
-    private List<TestArticle> getDiffFiveArticles() {
+    private List<TestArticle> createDiffFiveArticles() {
         List<TestArticle> result = new ArrayList<>();
         for (int i = 1; i <= 5; i++) {
-            TestArticle testArticle = getTestArticleDiff(i);
+            TestArticle testArticle = createTestArticleWithOffset(i);
             result.add(testArticle);
         }
         return result;
     }
 
-    private TestArticle getTestArticleDiff(int number) {
+    private TestArticle createTestArticleWithOffset(int number) {
         return TestArticle.of(now.plusMinutes(number), "createdName" + number, now.plusMinutes(modifiedTime + number), "modifiedName" + number, "title" + number, "content" + number, "hashtag" + number);
     }
 
-    private TestArticle getTestArticleAuditingFieldDiff(int number) {
+    private TestArticle createTestArticleWithOffsetAuditingFields(int number) {
         return TestArticle.of(now.plusMinutes(number), "createdName" + number, now.plusMinutes(modifiedTime + number), "modifiedName" + number, "title", "content", "hashtag");
     }
 

--- a/src/test/java/com/fastcampus/projectboard/domain/test/TestArticleHashcodeTest.java
+++ b/src/test/java/com/fastcampus/projectboard/domain/test/TestArticleHashcodeTest.java
@@ -1,0 +1,32 @@
+package com.fastcampus.projectboard.domain.test;
+
+import com.fastcampus.projectboard.domain.TestArticle;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Objects.hash 함수의 중첩 호출여부에 따라 값이 달라짐을 보여주는 테스트")
+public class TestArticleHashcodeTest {
+
+    @DisplayName("Objects.hash 함수를 다시 호출하면 hashcode값은 달라진다.")
+    @Test
+    void givenTestArticleHashcode_whenCalculateHashcodeAgain_thenDifferentHashcode() {
+        // Given
+        int hashcode = createTestArticle().hashCode();
+
+        // When
+        int againCalculateHashcode = Objects.hash(hashcode);
+
+        // Then
+        assertThat(againCalculateHashcode).isNotEqualTo(hashcode);
+    }
+
+    private TestArticle createTestArticle() {
+        LocalDateTime now = LocalDateTime.now();
+        return TestArticle.of(now,"gunhee",now,"gunhee","title","content","#hashtag");
+    }
+}


### PR DESCRIPTION
https://github.com/hegunhee/fastcampus-project-board/pull/20#pullrequestreview-2373331710
전에는 제품이 급하게 나가야되는 바람에 코멘트사항을 확인만 했던것인데
현재 시간이 비어서 해당 테스트코드를 리팩토링해서 올립니다.

테스트 케이스에서 동일한 객체를 받아오도록 변경,
테스트 객체를 생성하는 메서드 명을 직관적이게 변경,
Hashcode 관련 코드를 다른 테스트클래스로 분리, 

This closes #42 